### PR TITLE
Feat/8194 add stackscli support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,10 +187,14 @@ terraform.rc
 .terraform.lock.hcl
 
 # Testing Directories
+envfile
 test
 tfplan
 inspec.lock
+destroy
 deploy/deploytesting/*
 tf_outputs.yml
 deploy/tests/vendor
 inspec_inputs.yml
+outputs/*
+tmp/*

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -148,7 +148,7 @@ stages:
         dependsOn: ${{ stage.dependsOn }}
         condition: and(succeeded(), or(${{ stage.condition }}, ${{ parameters.force_deploy }}))
         variables:
-          - group: stacks-credentials-${{ stage.environment_shortname }}-kv
+          - group: stacks-credentials-nonprod-kv
         jobs:
           - deployment: ${{ stage.deployment_infra }}
             environment: ${{ variables.domain }}-${{ stage.environment_shortname }}

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -148,8 +148,7 @@ stages:
         dependsOn: ${{ stage.dependsOn }}
         condition: and(succeeded(), or(${{ stage.condition }}, ${{ parameters.force_deploy }}))
         variables:
-          # Pull in the non-production credentials for the build to use
-          - group: stacks-credentials-nonprod-kv
+          - group: stacks-credentials-${{ stage.environment_shortname }}-kv
         jobs:
           - deployment: ${{ stage.deployment_infra }}
             environment: ${{ variables.domain }}-${{ stage.environment_shortname }}

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -194,11 +194,11 @@ stages:
                             script: |
                               taskctl infrastructure_destroy
                           env:
+                            CLOUD_PLATFORM: azure
                             TF_FILE_LOCATION: /app/deploy/terraform/azure
                             TF_BACKEND_INIT: "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)"
                             TF_BACKEND_DESTROY_PLAN: "-input=false,-out=\"destroy\""
                             TF_VAR_name_environment: ${{ stage.environment_shortname }}
-
 
                     # Create the resources
                     - ${{ if eq(parameters.deploy, true) }}:
@@ -209,11 +209,11 @@ stages:
                             script: |
                               taskctl infrastructure
                           env:
+                            CLOUD_PLATFORM: azure
                             TF_FILE_LOCATION: /app/deploy/terraform/azure
                             TF_BACKEND_INIT: "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)"
                             TF_BACKEND_PLAN: "-input=false,-out=\"tfplan\""
                             TF_VAR_name_environment: ${{ stage.environment_shortname }}
-
 
                     # Perform infrastructure tests
                     - ${{ if eq(parameters.deploy, true) }}:

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -233,10 +233,10 @@ stages:
                             TF_FILE_LOCATION: /app/deploy/terraform/azure
                             TF_VAR_name_environment: ${{ stage.environment_shortname }}
                             TF_VAR_location: $(region)
-                            ARM_TENANT_ID: $(azure-tenant-id)
-                            ARM_SUBSCRIPTION_ID: $(azure-subscription-id)
-                            ARM_CLIENT_ID: $(azure-client-id)
-                            ARM_CLIENT_SECRET: $(azure-client-secret)
+                            AZURE_TENANT_ID: $(azure-tenant-id)
+                            AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+                            AZURE_CLIENT_ID: $(azure-client-id)
+                            AZURE_CLIENT_SECRET: $(azure-client-secret)
 
                     - ${{ if eq(parameters.deploy, true) }}:
                         - task: PublishTestResults@2

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -233,6 +233,10 @@ stages:
                             TF_FILE_LOCATION: /app/deploy/terraform/azure
                             TF_VAR_name_environment: ${{ stage.environment_shortname }}
                             TF_VAR_location: $(region)
+                            ARM_TENANT_ID: $(azure-tenant-id)
+                            ARM_SUBSCRIPTION_ID: $(azure-subscription-id)
+                            ARM_CLIENT_ID: $(azure-client-id)
+                            ARM_CLIENT_SECRET: $(azure-client-secret)
 
                     - ${{ if eq(parameters.deploy, true) }}:
                         - task: PublishTestResults@2

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -101,7 +101,7 @@ stages:
         pool:
           vmImage: $(pool_vm_image)
         steps:
-          - template: ../templates/setup.yml
+          - template: ./templates/setup.yml
             parameters:
               TaskctlVersion: ${{ variables.TaskctlVersion }}
 
@@ -160,7 +160,7 @@ stages:
               runOnce:
                 deploy:
                   steps:
-                    - template: ../templates/setup.yml
+                    - template: ./templates/setup.yml
                       parameters:
                         TaskctlVersion: ${{ variables.TaskctlVersion }}
 
@@ -183,7 +183,7 @@ stages:
 
                     # Upload the Terraform variables file and the plan for debugging
                     - ${{ if eq(parameters.upload, true) }}:
-                        - template: ../templates/upload.yml
+                        - template: ./templates/upload.yml
 
                     # Remove the infrastructure if the parameter has been set
                     - ${{ if eq(parameters.destroy, true) }}:
@@ -217,7 +217,7 @@ stages:
 
                     # Perform infrastructure tests
                     - ${{ if eq(parameters.deploy, true) }}:
-                        - template: ../templates/infra-tests.yml
+                        - template: ./templates/infra-tests.yml
                           parameters:
                             CHEF_LICENSE: $(CHEF_LICENSE)
                             INSPEC_FILES: /app/deploy/tests
@@ -250,7 +250,7 @@ stages:
         pool:
           vmImage: $(pool_vm_image)
         steps:
-          - template: ../templates/setup.yml
+          - template: ./templates/setup.yml
             parameters:
               TaskctlVersion: ${{ variables.TaskctlVersion }}
 

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -206,7 +206,7 @@ stages:
                     # Create the resources
                     - ${{ if eq(parameters.deploy, true) }}:
                         - task: Bash@3
-                          displayName: Deploy ACA
+                          displayName: Deploy environment
                           inputs:
                             targetType: inline
                             script: |

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -15,9 +15,9 @@ pr:
       - "main"
   paths:
     include:
-      - cicd/build/azDevOps/*
-      - cicd/build/taskctl/*
-      - cicd/deploy/terraform/azure/*
+      - build/azDevOps/*
+      - build/taskctl/*
+      - deploy/terraform/azure/*
 
 trigger:
   branches:
@@ -25,9 +25,9 @@ trigger:
       - "main"
   paths:
     include:
-      - cicd/build/azDevOps/*
-      - cicd/build/taskctl/*
-      - cicd/deploy/terraform/azure/*
+      - build/azDevOps/*
+      - build/taskctl/*
+      - deploy/terraform/azure/*
 
 # Configure parameters for running the build
 parameters:
@@ -149,7 +149,7 @@ stages:
         condition: and(succeeded(), or(${{ stage.condition }}, ${{ parameters.force_deploy }}))
         variables:
           # Pull in the non-production credentials for the build to use
-          - group: ensono-sp-creds #stacks-credentials-nonprod-kv #ensono-sp-creds
+          - group: stacks-credentials-nonprod-kv
         jobs:
           - deployment: ${{ stage.deployment_infra }}
             environment: ${{ variables.domain }}-${{ stage.environment_shortname }}
@@ -194,7 +194,11 @@ stages:
                             script: |
                               taskctl infrastructure_destroy
                           env:
-                            CLOUD_PLATFORM: azure
+                            CLOUD_PLATFORM: "$(cloud_platform)"
+                            ARM_TENANT_ID: $(azure-tenant-id)
+                            ARM_SUBSCRIPTION_ID: $(azure-subscription-id)
+                            ARM_CLIENT_ID: $(azure-client-id)
+                            ARM_CLIENT_SECRET: $(azure-client-secret)
                             TF_FILE_LOCATION: /app/deploy/terraform/azure
                             TF_BACKEND_INIT: "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)"
                             TF_BACKEND_DESTROY_PLAN: "-input=false,-out=\"destroy\""
@@ -209,7 +213,11 @@ stages:
                             script: |
                               taskctl infrastructure
                           env:
-                            CLOUD_PLATFORM: azure
+                            CLOUD_PLATFORM: "$(cloud_platform)"
+                            ARM_TENANT_ID: $(azure-tenant-id)
+                            ARM_SUBSCRIPTION_ID: $(azure-subscription-id)
+                            ARM_CLIENT_ID: $(azure-client-id)
+                            ARM_CLIENT_SECRET: $(azure-client-secret)
                             TF_FILE_LOCATION: /app/deploy/terraform/azure
                             TF_BACKEND_INIT: "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)"
                             TF_BACKEND_PLAN: "-input=false,-out=\"tfplan\""

--- a/build/azDevOps/azure/pipeline-vars.yml
+++ b/build/azDevOps/azure/pipeline-vars.yml
@@ -16,7 +16,7 @@ variables:
   # which domain fo the company is this. e.g. core resources, or front end
   # This is not a network domain
   - name: domain
-    value: aca
+    value: bal
 
   # -------- Terraform remote state
   # Stacks operates Terraform states based on workspaces **IT IS VERY IMPORTANT** that you ensure a unique name for each application definition
@@ -24,9 +24,9 @@ variables:
   # there are some best practices around this if you are going for feature based environments
   # avoid running anything past dev that is not on master
   - name: tf_state_rg
-    value: stacks-terraform-state
+    value: bal-aca-testing
   - name: tf_state_storage
-    value: stacksstatehjfis
+    value: balacatesting
   - name: tf_state_container
     value: tfstate
 

--- a/build/azDevOps/azure/pipeline-vars.yml
+++ b/build/azDevOps/azure/pipeline-vars.yml
@@ -24,9 +24,9 @@ variables:
   # there are some best practices around this if you are going for feature based environments
   # avoid running anything past dev that is not on master
   - name: tf_state_rg
-    value: bal-aca-testing
+    value: stacks-terraform-state
   - name: tf_state_storage
-    value: balacatesting
+    value: stacksstatehjfis
   - name: tf_state_container
     value: tfstate
 

--- a/build/azDevOps/azure/pipeline-vars.yml
+++ b/build/azDevOps/azure/pipeline-vars.yml
@@ -16,7 +16,7 @@ variables:
   # which domain fo the company is this. e.g. core resources, or front end
   # This is not a network domain
   - name: domain
-    value: bal
+    value: aca
 
   # -------- Terraform remote state
   # Stacks operates Terraform states based on workspaces **IT IS VERY IMPORTANT** that you ensure a unique name for each application definition

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -36,4 +36,3 @@ steps:
       AZURE_CLIENT_SECRET: ${{ parameters.AZURE_CLIENT_SECRET }}
       AZURE_SUBSCRIPTION_ID: ${{ parameters.AZURE_SUBSCRIPTION_ID }}
       AZURE_TENANT_ID: ${{ parameters.AZURE_TENANT_ID }}
-      

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -36,3 +36,8 @@ steps:
       AZURE_CLIENT_SECRET: ${{ parameters.AZURE_CLIENT_SECRET }}
       AZURE_SUBSCRIPTION_ID: ${{ parameters.AZURE_SUBSCRIPTION_ID }}
       AZURE_TENANT_ID: ${{ parameters.AZURE_TENANT_ID }}
+
+      ARM_CLIENT_ID: ${{ parameters.AZURE_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ parameters.AZURE_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ parameters.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ parameters.AZURE_TENANT_ID }}

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -7,6 +7,10 @@ parameters:
   TF_FILE_LOCATION:
   TF_VAR_name_environment:
   TF_VAR_location:
+  AZURE_CLIENT_ID:
+  AZURE_CLIENT_SECRET:
+  AZURE_SUBSCRIPTION_ID:
+  AZURE_TENANT_ID:
   # TF_VAR_resource_group_name:
 
 steps:
@@ -28,7 +32,8 @@ steps:
 
       # Ensure that the env vars are set for access
       # The following are the env vars that Inspec requires for authentication with Azure
-      AZURE_CLIENT_ID: $(ARM_CLIENT_ID)
-      AZURE_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
-      AZURE_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
-      AZURE_TENANT_ID: $(ARM_TENANT_ID)
+      AZURE_CLIENT_ID: ${{ parameters.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ parameters.AZURE_CLIENT_SECRET }}
+      AZURE_SUBSCRIPTION_ID: ${{ parameters.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ parameters.AZURE_TENANT_ID }}
+      

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -33,7 +33,7 @@ steps:
       #AZURE_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
       #AZURE_TENANT_ID: $(ARM_TENANT_ID)
 
-      AZURE_CLIENT_ID: $(azure-tenant-id)
+      AZURE_TENANT_ID: $(azure-tenant-id)
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_CLIENT_ID: $(azure-client-id)
       AZURE_CLIENT_SECRET: $(azure-client-secret)

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -28,12 +28,7 @@ steps:
 
       # Ensure that the env vars are set for access
       # The following are the env vars that Inspec requires for authentication with Azure
-      #AZURE_CLIENT_ID: $(ARM_CLIENT_ID)
-      #AZURE_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
-      #AZURE_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
-      #AZURE_TENANT_ID: $(ARM_TENANT_ID)
-
-      AZURE_TENANT_ID: $(azure-tenant-id)
-      AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
-      AZURE_CLIENT_ID: $(azure-client-id)
-      AZURE_CLIENT_SECRET: $(azure-client-secret)
+      AZURE_CLIENT_ID: $(ARM_CLIENT_ID)
+      AZURE_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+      AZURE_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
+      AZURE_TENANT_ID: $(ARM_TENANT_ID)

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -35,5 +35,5 @@ steps:
 
       AZURE_CLIENT_ID: $(azure-tenant-id)
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
-      ARM_CLIENT_ID: $(azure-client-id)
+      AZURE_CLIENT_ID: $(azure-client-id)
       AZURE_CLIENT_SECRET: $(azure-client-secret)

--- a/build/azDevOps/azure/templates/infra-tests.yml
+++ b/build/azDevOps/azure/templates/infra-tests.yml
@@ -28,7 +28,12 @@ steps:
 
       # Ensure that the env vars are set for access
       # The following are the env vars that Inspec requires for authentication with Azure
-      AZURE_CLIENT_ID: $(ARM_CLIENT_ID)
-      AZURE_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
-      AZURE_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
-      AZURE_TENANT_ID: $(ARM_TENANT_ID)
+      #AZURE_CLIENT_ID: $(ARM_CLIENT_ID)
+      #AZURE_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+      #AZURE_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
+      #AZURE_TENANT_ID: $(ARM_TENANT_ID)
+
+      AZURE_CLIENT_ID: $(azure-tenant-id)
+      AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+      ARM_CLIENT_ID: $(azure-client-id)
+      AZURE_CLIENT_SECRET: $(azure-client-secret)

--- a/build/config/pdf/base-theme.yml
+++ b/build/config/pdf/base-theme.yml
@@ -1,0 +1,293 @@
+font:
+  catalog:
+    # Noto Serif supports Latin, Latin-1 Supplement, Latin Extended-A, Greek, Cyrillic, Vietnamese & an assortment of symbols
+    Noto Serif:
+      normal: GEM_FONTS_DIR/notoserif-regular-subset.ttf
+      bold: GEM_FONTS_DIR/notoserif-bold-subset.ttf
+      italic: GEM_FONTS_DIR/notoserif-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/notoserif-bold_italic-subset.ttf
+    # M+ 1mn supports ASCII and the circled numbers used for conums
+    M+ 1mn:
+      normal: GEM_FONTS_DIR/mplus1mn-regular-subset.ttf
+      bold: GEM_FONTS_DIR/mplus1mn-bold-subset.ttf
+      italic: GEM_FONTS_DIR/mplus1mn-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/mplus1mn-bold_italic-subset.ttf
+page:
+  background_color: FFFFFF
+  layout: portrait
+  initial_zoom: FitH
+  margin: [0.5in, 0.67in, 0.67in, 0.67in]
+  # margin_inner and margin_outer keys are used for recto/verso print margins when media=prepress
+  margin_inner: 0.75in
+  margin_outer: 0.59in
+  size: A4
+base:
+  align: justify
+  # color as hex string (leading # is optional)
+  font_color: 333333
+  # color as RGB array
+  # font_color: [51, 51, 51]
+  # color as CMYK array (approximated)
+  # font_color: [0, 0, 0, 0.92]
+  # font_color: [0, 0, 0, 92%]
+  font_family: Noto Serif
+  # choose one of these font_size/line_height_length combinations
+  # font_size: 14
+  # line_height_length: 20
+  # font_size: 11.25
+  # line_height_length: 18
+  # font_size: 11.2
+  # line_height_length: 16
+  font_size: 10.5
+  # line_height_length: 15
+  # correct line height for Noto Serif metrics
+  line_height_length: 12
+  # font_size: 11.25
+  # line_height_length: 18
+  line_height: $base_line_height_length / $base_font_size
+  font_size_large: round($base_font_size * 1.25)
+  font_size_small: round($base_font_size * 0.85)
+  font_size_min: $base_font_size * 0.75
+  font_style: normal
+  border_color: EEEEEE
+  border_radius: 4
+  border_width: 0.5
+role:
+  line-through:
+    text_decoration: line-through
+  underline:
+    text_decoration: underline
+  big:
+    font_size: $base_font_size_large
+  small:
+    font_size: $base_font_size_small
+  subtitle:
+    font_color: 999999
+    font_size: 0.8em
+    font_style: normal_italic
+# FIXME vertical_rhythm is weird; we should think in terms of ems
+# vertical_rhythm: $base_line_height_length * 2 / 3
+# correct line height for Noto Serif metrics (comes with built-in line height)
+vertical_rhythm: $base_line_height_length
+horizontal_rhythm: $base_line_height_length
+link:
+  font_color: 428BCA
+# literal is currently used for inline monospaced in prose and table cells
+literal:
+  font_color: B12146
+  font_family: M+ 1mn
+button:
+  content: "[\u2009%s\u2009]"
+  font_style: bold
+key:
+  background_color: F5F5F5
+  border_color: CCCCCC
+  border_offset: 2
+  border_radius: 2
+  border_width: 0.5
+  font_family: $literal_font_family
+  separator: "\u202f+\u202f"
+mark:
+  background_color: FFFF00
+  border_offset: 1
+menu:
+  caret_content: " <font size=\"1.15em\" color=\"#B12146\">\u203a</font> "
+  font_style: bold
+heading:
+  align: left
+  font_color: $base_font_color
+  font_style: bold
+  # h1 is used for part titles (book doctype) or the doctitle (article doctype)
+  h1_font_size: floor($base_font_size * 2.6)
+  # h2 is used for chapter titles (book doctype only)
+  h2_font_size: floor($base_font_size * 2.15)
+  h3_font_size: round($base_font_size * 1.7)
+  h4_font_size: $base_font_size_large
+  h5_font_size: $base_font_size
+  h6_font_size: $base_font_size_small
+  # line_height: 1.4
+  # correct line height for Noto Serif metrics (comes with built-in line height)
+  line_height: 1
+  margin_top: $vertical_rhythm * 0.4
+  margin_bottom: $vertical_rhythm * 0.9
+  min_height_after: $base_line_height_length * 1.5
+title_page:
+  align: right
+  logo:
+    top: 10%
+  title:
+    top: 55%
+    font_size: $heading_h1_font_size
+    font_color: $role_subtitle_font_color
+    line_height: 0.9
+  subtitle:
+    font_size: $heading_h3_font_size
+    font_style: bold_italic
+    line_height: 1
+  authors:
+    margin_top: $base_font_size * 1.25
+    font_size: $base_font_size_large
+    font_color: 181818
+  revision:
+    margin_top: $base_font_size * 1.25
+block:
+  margin_bottom: $vertical_rhythm
+caption:
+  align: left
+  font_size: $base_font_size * 0.95
+  font_style: italic
+  # FIXME perhaps set line_height instead of / in addition to margins?
+  margin_inside: $vertical_rhythm / 3
+  margin_outside: 0
+lead:
+  font_size: $base_font_size_large
+  line_height: 1.4
+abstract:
+  font_color: 5C6266
+  font_size: $lead_font_size
+  line_height: $lead_line_height
+  font_style: italic
+  first_line_font_style: bold
+  title:
+    align: center
+    font_color: $heading_font_color
+    font_size: $heading_h4_font_size
+    font_style: $heading_font_style
+admonition:
+  column_rule_color: $base_border_color
+  column_rule_width: $base_border_width
+  padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+  # icon:
+  #  tip:
+  #    name: far-lightbulb
+  #    stroke_color: 111111
+  #    size: 24
+  label:
+    text_transform: uppercase
+    font_style: bold
+blockquote:
+  font_size: $base_font_size_large
+  border_color: $base_border_color
+  border_width: 0
+  border_left_width: 5
+  # FIXME disable negative padding bottom once margin collapsing is implemented
+  padding:
+    [
+      0,
+      $horizontal_rhythm,
+      $block_margin_bottom * -0.75,
+      $horizontal_rhythm + $blockquote_border_left_width / 2,
+    ]
+  cite:
+    font_size: $base_font_size_small
+    font_color: $role_subtitle_font_color
+verse:
+  font_size: $blockquote_font_size
+  border_color: $blockquote_border_color
+  border_width: $blockquote_border_width
+  border_left_width: $blockquote_border_left_width
+  padding: $blockquote_padding
+  cite:
+    font_size: $blockquote_cite_font_size
+    font_color: $blockquote_cite_font_color
+# code is used for source blocks (perhaps change to source or listing?)
+code:
+  font_color: $base_font_color
+  font_family: $literal_font_family
+  font_size: ceil($base_font_size)
+  padding: $code_font_size
+  line_height: 1.25
+  # line_gap is an experimental property to control how a background color is applied to an inline block element
+  line_gap: 3.8
+  background_color: F5F5F5
+  border_color: CCCCCC
+  border_radius: $base_border_radius
+  border_width: 0.75
+  callout_list:
+    margin_top: -$block_margin_bottom / 2
+conum:
+  font_family: $literal_font_family
+  font_color: $literal_font_color
+  font_size: $base_font_size
+  line_height: 4 / 3
+  glyphs: circled
+example:
+  border_color: $base_border_color
+  border_radius: $base_border_radius
+  border_width: 0.75
+  background_color: $page_background_color
+  # FIXME reenable padding bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
+image:
+  align: right
+prose:
+  margin_bottom: $block_margin_bottom
+sidebar:
+  background_color: EEEEEE
+  border_color: E1E1E1
+  border_radius: $base_border_radius
+  border_width: $base_border_width
+  # FIXME reenable padding bottom once margin collapsing is implemented
+  padding:
+    [$vertical_rhythm, $vertical_rhythm * 1.25, 0, $vertical_rhythm * 1.25]
+  title:
+    align: center
+    font_color: $heading_font_color
+    font_size: $heading_h4_font_size
+    font_style: $heading_font_style
+thematic_break:
+  border_color: $base_border_color
+  border_style: solid
+  border_width: $base_border_width
+  margin_top: $vertical_rhythm * 0.5
+  margin_bottom: $vertical_rhythm * 1.5
+description_list:
+  term_font_style: bold
+  term_spacing: $vertical_rhythm / 4
+  description_indent: $horizontal_rhythm * 1.25
+outline_list:
+  indent: $horizontal_rhythm * 1.5
+  # marker_font_color: 404040
+  # NOTE outline_list_item_spacing applies to list items that do not have complex content
+  item_spacing: $vertical_rhythm / 2
+table:
+  background_color: $page_background_color
+  border_color: DDDDDD
+  border_width: $base_border_width
+  cell_padding: 3
+  head:
+    font_style: bold
+    border_bottom_width: $base_border_width * 2.5
+  body:
+    stripe_background_color: F9F9F9
+  foot:
+    background_color: F0F0F0
+toc:
+  indent: $horizontal_rhythm
+  line_height: 1.4
+  dot_leader:
+    # content: ". "
+    font_color: A9A9A9
+    # levels: 2 3
+footnotes:
+  font_size: round($base_font_size * 0.75)
+  item_spacing: $outline_list_item_spacing / 2
+header:
+  font_size: $base_font_size_small
+  line_height: 1
+  vertical_align: middle
+footer:
+  font_size: $base_font_size_small
+  # NOTE if background_color is set, background and border will span width of page
+  border_color: DDDDDD
+  border_width: 0.25
+  height: $base_line_height_length * 2.5
+  line_height: 1
+  padding: [$base_line_height_length / 2, 1, 0, 1]
+  vertical_align: top
+  recto:
+    right:
+      content: "{page-number}"
+  verso:
+    left:
+      content: $footer_recto_right_content

--- a/build/config/pdf/theme.yml
+++ b/build/config/pdf/theme.yml
@@ -1,0 +1,56 @@
+# Extend the default theme
+extends: default
+
+page:
+  size: A4
+  margin: [2cm, 1.27cm, 1.27cm, 1.27cm]
+  background_image: "image:../../../docs/images/page-image.png[position=top right]"
+
+# Add extra fonts to the catalog
+font:
+  catalog:
+    merge: true
+    Opensans:
+      normal: OpenSans-Regular.ttf
+      italic: OpenSans-Italic.ttf
+      bold: OpenSans-Bold.ttf
+      bold_italic: OpenSans-BoldItalic.ttf
+
+# State what fonts should be used
+base:
+  font-family: Opensans
+
+# Configure the header to add a logo
+header:
+  height: $base_line_height_length * 3.5
+  border_width: 0.25
+  border_color: dddddd
+  recto:
+    columns: "<40% =20% >40%"
+    left:
+      content: "image:../../../docs/images/ensono-digital.svg[Ensono Digital,100]"
+    center:
+      content: ""
+  verso:
+    left:
+      content: $header_recto_left_content
+    center:
+      content: $header_recto_center_content
+
+# Define the table style
+table:
+  caption:
+    side: bottom
+  head:
+    background-color: "#08c1a7"
+    font-color: "#ffffff"
+
+role:
+  highlight:
+    background-color: "#fe6e69"
+  notes:
+    background_color: "#6941eb"
+    font_color: "#00ff00"
+
+heading:
+  font-color: "#6941eb"

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -26,6 +26,7 @@ contexts:
         - path
         - home
         - kubeconfig
+        - tmpdir
 
   infratests:
     executable:
@@ -54,33 +55,7 @@ contexts:
         - path
         - home
         - PSModulePath
-
-  powershell-python:
-    executable:
-      bin: docker
-      args:
-        - run
-        - --rm
-        - -v
-        - ${PWD}:/app
-        - -v
-        - /var/run/docker.sock:/var/run/docker.sock
-        - -e
-        - PSModulePath=/modules
-        - -w
-        - /app
-        - --env-file
-        - envfile
-        - amidostacks/runner-pwsh:0.4.60-stable
-        - pwsh
-        - -NoProfile
-        - -Command
-    quote: "'"
-    envfile:
-      generate: true
-      exclude:
-        - path
-        - home
+        - tmpdir
 
   docsenv:
     executable:
@@ -106,3 +81,4 @@ contexts:
       exclude:
         - path
         - home
+        - tmpdir

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -123,7 +123,6 @@ tasks:
         Invoke-Terraform -Workspace -Arguments $env:TF_VAR_name_environment -Path $env:TF_FILE_LOCATION
         Invoke-Terraform -Output -Path $env:TF_FILE_LOCATION | /app/build/scripts/Set-EnvironmentVars.ps1 -prefix "TFOUT" -key "value" -passthru | ConvertTo-Yaml | Out-File -Path ${PWD}/inspec_inputs.yml
         Add-Content -Path ${PWD}/inspec_inputs.yml -Value "location: ${env:TF_VAR_location}"
-        Invoke-Inspec -execute -arguments "--input-file ${PWD}/inspec_inputs.yml" -path $env:INSPEC_FILES
 
   _docs:
     description: Build Docs for ACI

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -35,7 +35,7 @@ tasks:
     context: powershell
     description: Create Terraform variables file
     command:
-      - /app/cicd/build/scripts/Set-TFVars.ps1 | Out-File -Path "${env:TF_FILE_LOCATION}/terraform.tfvars"
+      - /app/build/scripts/Set-TFVars.ps1 | Out-File -Path "${env:TF_FILE_LOCATION}/terraform.tfvars"
       - dir ${env:TF_FILE_LOCATION}
 
   infra:plan:
@@ -94,13 +94,13 @@ tasks:
     context: powershell
     description: Create a shell script to configure the environment variables
     command:
-      - New-EnvConfig -Path /app/cicd/build/config/stage_envvars.yml -ScriptPath /app/local
+      - New-EnvConfig -Path /app/build/config/stage_envvars.yml -ScriptPath /app/local
 
   setup:environment:
     context: powershell
     description: Ensure that the environment is configured correctly
     command:
-      - Confirm-Environment -Path /app/cicd/build/config/stage_envvars.yml
+      - Confirm-Environment -Path /app/build/config/stage_envvars.yml
 
   tests:infra:init:
     context: infratests
@@ -121,7 +121,7 @@ tasks:
     command:
       - |
         Invoke-Terraform -Workspace -Arguments $env:TF_VAR_name_environment -Path $env:TF_FILE_LOCATION
-        Invoke-Terraform -Output -Path $env:TF_FILE_LOCATION | /app/cicd/build/scripts/Set-EnvironmentVars.ps1 -prefix "TFOUT" -key "value" -passthru | ConvertTo-Yaml | Out-File -Path ${PWD}/inspec_inputs.yml
+        Invoke-Terraform -Output -Path $env:TF_FILE_LOCATION | /app/build/scripts/Set-EnvironmentVars.ps1 -prefix "TFOUT" -key "value" -passthru | ConvertTo-Yaml | Out-File -Path ${PWD}/inspec_inputs.yml
         Add-Content -Path ${PWD}/inspec_inputs.yml -Value "location: ${env:TF_VAR_location}"
         Invoke-Inspec -execute -arguments "--input-file ${PWD}/inspec_inputs.yml" -path $env:INSPEC_FILES
 
@@ -129,7 +129,7 @@ tasks:
     description: Build Docs for ACI
     context: docsenv
     command: |
-      /app/cicd/build/scripts/New-Glossary.ps1 -docpath /app/docs -path /app/tmp/glossary.adoc
+      /app/build/scripts/New-Glossary.ps1 -docpath /app/docs -path /app/tmp/glossary.adoc
       Invoke-AsciiDoc -PDF -basepath /app -config /app/docs.json -debug
 
   _release:
@@ -156,7 +156,7 @@ tasks:
       - Get-ChildItem env:/
 
   debug:sleep:
-    context: powershell
+    context: infratests
     command:
       - echo "Sleeping for {{ .sleep }}"
       - sleep {{ .sleep }}

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -156,7 +156,7 @@ tasks:
       - Get-ChildItem env:/
 
   debug:sleep:
-    context: infratests
+    context: powershell
     command:
       - echo "Sleeping for {{ .sleep }}"
       - sleep {{ .sleep }}

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -123,6 +123,7 @@ tasks:
         Invoke-Terraform -Workspace -Arguments $env:TF_VAR_name_environment -Path $env:TF_FILE_LOCATION
         Invoke-Terraform -Output -Path $env:TF_FILE_LOCATION | /app/build/scripts/Set-EnvironmentVars.ps1 -prefix "TFOUT" -key "value" -passthru | ConvertTo-Yaml | Out-File -Path ${PWD}/inspec_inputs.yml
         Add-Content -Path ${PWD}/inspec_inputs.yml -Value "location: ${env:TF_VAR_location}"
+        Invoke-Inspec -execute -arguments "--input-file ${PWD}/inspec_inputs.yml" -path $env:INSPEC_FILES
 
   _docs:
     description: Build Docs for ACI

--- a/deploy/terraform/azure/.terraform.lock.hcl
+++ b/deploy/terraform/azure/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.108.0"
   constraints = "~> 3.108.0"
   hashes = [
-    "h1:Hi1qvx4ADlHsEArf05M5DAqN6PA9g1eYFVQhUFiyHnM=",
+    "h1:RIFBFTXz4X48JDHjbQHX4y400ax1/uEzMVFZgX3/z3w=",
     "zh:2afecf948fd702bc08c87d9114595809d011f99a70a12dbf6bc67a12d0bee5fc",
     "zh:395b6d1384a579867064e62d49b0b91e15919c33b03ea8b5031c2779bfa16b3d",
     "zh:3e5594c59b6b02bc6e0f4c3de71aa2ab992494c53725fb3c64d36745f3814ef3",

--- a/deploy/terraform/azure/main.tf
+++ b/deploy/terraform/azure/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_log_analytics_workspace" "la" {
 }
 
 module "acae" {
-  source = "git::https://github.com/Ensono/terraform-azurerm-aca?ref=feature/7427-terraform-module-for-aca"
+  source = "git::https://github.com/Ensono/terraform-azurerm-aca?ref=1.0.1"
 
   resource_group_name              = azurerm_resource_group.default.name
   location                         = azurerm_resource_group.default.location

--- a/deploy/terraform/azure/variables.tf
+++ b/deploy/terraform/azure/variables.tf
@@ -17,6 +17,10 @@ variable "name_component" {
   type        = string
 }
 
+variable "name_environment" {
+  type = string
+}
+
 variable "stage" {
   type = string
 }

--- a/deploy/tests/inspec.lock
+++ b/deploy/tests/inspec.lock
@@ -4,5 +4,5 @@ depends:
 - name: inspec-azure
   resolved_source:
     url: https://github.com/inspec/inspec-azure/archive/main.tar.gz
-    sha256: ee709cf1dcb38e89772dcd886c19b2f1e3e89a55089d19d3e928b5d8893f782f
+    sha256: 42fad1e9bbfd2051af3d2777903110bff4ab9b5d06e4e74db42f0e61d449c637
   version_constraints: []

--- a/docs/getting_started.adoc
+++ b/docs/getting_started.adoc
@@ -26,10 +26,10 @@ In order to run the pipeline locally a number of environment variables are requi
 [cols="2,3,1,3,2,2",options="header",stripes=even]
 |===
 | Name                        | Description                                                                 | Type           | Default | Example | Required
-| `TF_VAR_FILE_LOCATION`     | Path to the Terraform template files                                        | string              | "/deploy/terraform"      | -      | [green]#icon:check[]#
-| `TF_VAR_BACKEND_INIT`      | Arguments that should be passed to Terraform during the init process        | string              | "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)       | -      | [red]#icon:times[]#
-| `TF_VAR_BACKEND_PLAN`      | Arguments that should be passed to Terraform during the plan process        | string              | "-input=false,-out=\"tfplan\""      | -       | [red]#icon:times[]# 
-| `TF_VAR_name_company`      | Name of the company that the cluster is being built for                     |  string              | - | "myCompany"      | [red]#icon:times[]#
+| `TF_FILE_LOCATION`     | Path to the Terraform template files                                        | string              | "/deploy/terraform"      | -      | [green]#icon:check[]#
+| `TF_BACKEND_INIT`      | Arguments that should be passed to Terraform during the init process        | string              | "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)       | -      | [green]#icon:check[]#
+| `TF_BACKEND_PLAN`      | Arguments that should be passed to Terraform during the plan process        | string              | "-input=false,-out=\"tfplan\""      | -       | [green]#icon:check[]# 
+| `TF_VAR_name_company`      | Name of the company that the cluster is being built for                     |  string              | - | "myCompany"      | [green]#icon:check[]#
 | `TF_VAR_name_project`      | Name of the project                                                         |   string             | - | "myProject"        | [green]#icon:check[]#
 | `TF_VAR_name_component`    |                                                                             |   string             | - | "myComponent"     | [green]#icon:check[]#
 | `TF_VAR_name_environment`  |                                                                             |   string             | -       | "myEnv"       | [green]#icon:check[]#

--- a/src/deploy-aca.yml
+++ b/src/deploy-aca.yml
@@ -61,7 +61,7 @@ parameters:
     default: false
 
 variables:
-  - template: ../cicd/build/azDevOps/azure/pipeline-vars.yml  
+  - template: ../build/azDevOps/azure/pipeline-vars.yml  
   - template: aca-vars.yml
   - name: appname
     value: "frontendapp"
@@ -93,7 +93,7 @@ stages:
         pool:
           vmImage: $(pool_vm_image)
         steps:
-          - template: ../cicd/build/azDevOps/templates/setup.yml
+          - template: ../build/azDevOps/templates/setup.yml
             parameters:
               TaskctlVersion: ${{ variables.TaskctlVersion }}
 
@@ -151,7 +151,7 @@ stages:
               runOnce:
                 deploy:
                   steps:
-                    - template: ../cicd/build/azDevOps/templates/setup.yml
+                    - template: ../build/azDevOps/templates/setup.yml
                       parameters:
                         TaskctlVersion: ${{ variables.TaskctlVersion }}
 
@@ -185,7 +185,7 @@ stages:
 
                     # Upload the Terraform variables file and the plan for debugging
                     - ${{ if eq(parameters.upload, true) }}:
-                        - template: ../cicd/build/azDevOps/templates/upload.yml
+                        - template: ../build/azDevOps/templates/upload.yml
                           parameters:
                             contents: $(Build.SourcesDirectory)/src/terraform/*.tfvars
 
@@ -221,7 +221,7 @@ stages:
 
                     # Perform infrastructure tests
                     - ${{ if eq(parameters.deploy, true) }}:
-                        - template: ../cicd/build/azDevOps/templates/infra-tests.yml
+                        - template: ../build/azDevOps/templates/infra-tests.yml
                           parameters:
                             CHEF_LICENSE: $(CHEF_LICENSE)
                             INSPEC_FILES: /app/src/tests
@@ -255,7 +255,7 @@ stages:
         pool:
           vmImage: $(pool_vm_image)
         steps:
-          - template: ../cicd/build/azDevOps/templates/setup.yml
+          - template: ../build/azDevOps/templates/setup.yml
             parameters:
               TaskctlVersion: ${{ variables.TaskctlVersion }}
 

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -22,9 +22,6 @@ pipelines:
     - task: infra:plan
       depends_on:
         - infra:init
-    - task: infra:apply
-      depends_on:
-        - infra:plan
 
   infrastructure_destroy:
     - task: setup:environment

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -22,6 +22,9 @@ pipelines:
     - task: infra:plan
       depends_on:
         - infra:init
+    - task: infra:apply
+      depends_on:
+        - infra:plan
 
   infrastructure_destroy:
     - task: setup:environment

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -1,6 +1,6 @@
 import:
-  - ./cicd/build/taskctl/contexts.yaml
-  - ./cicd/build/taskctl/tasks.yaml
+  - ./build/taskctl/contexts.yaml
+  - ./build/taskctl/tasks.yaml
 
 pipelines:
   lint:


### PR DESCRIPTION
## 📲 What

Fixed the following issues:
- taskctl path was broken as it was expecting a cicd folder
- fixed infrastructure tests because the azure creds weren't being passed correctly
- fixed document generation because themes were missing
- fixed infrastructure destroy
- updated documentation as some variables were mandatory
- updated pipeline to reference "stacks-credentials-nonprod-kv" for azure creds. 
- updated to reference aca terraform module tag rather than branch

## 👀 Evidence

Generated this repo based on stacks-cli and this template repo:
Repo: https://github.com/Ensono/stacks-aca-test
Pipeline: https://amido-dev.visualstudio.com/Amido-Stacks/_build/results?buildId=33182&view=results
  - create ACA environment
  - run infra tests to ensure resources have created succesfully
  - destroy ACA environment

## TODO in separate PR:

I think we need to be able to provision the following as well similar to the AKS repo:
- ACR
- Key Vault
- App Insights